### PR TITLE
add hierarchical argument to property methods of 'size' feature

### DIFF
--- a/spec/rggen/default_register_map/register/size_spec.rb
+++ b/spec/rggen/default_register_map/register/size_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'register/size' do
 
   before(:all) do
     RgGen.enable(:global, [:bus_width, :enable_wide_register])
+    RgGen.enable(:register_file, :size)
     RgGen.enable(:register, :size)
     RgGen.enable(:bit_field, :bit_assignment)
   end
@@ -153,6 +154,42 @@ RSpec.describe 'register/size' do
           size [2, 3]
           bit_field { bit_assignment lsb: 32 }
         end
+
+        register_file do
+          register do
+            bit_field { bit_assignment lsb: 0 }
+          end
+
+          register do
+            size [2]
+            bit_field { bit_assignment lsb: 0 }
+          end
+
+          register do
+            size [2, 3]
+            bit_field { bit_assignment lsb: 0 }
+          end
+        end
+
+        register_file do
+          size [2, 3]
+
+          register_file do
+            register do
+              bit_field { bit_assignment lsb: 0 }
+            end
+
+            register do
+              size [2]
+              bit_field { bit_assignment lsb: 0 }
+            end
+
+            register do
+              size [2, 3]
+              bit_field { bit_assignment lsb: 0 }
+            end
+          end
+        end
       end
     end
 
@@ -174,6 +211,12 @@ RSpec.describe 'register/size' do
           expect(registers[6]).to have_property(:byte_size, 8)
           expect(registers[7]).to have_property(:byte_size, 16)
           expect(registers[8]).to have_property(:byte_size, 48)
+          expect(registers[9]).to have_property(:byte_size, 4)
+          expect(registers[10]).to have_property(:byte_size, 8)
+          expect(registers[11]).to have_property(:byte_size, 24)
+          expect(registers[12]).to have_property(:byte_size, 4)
+          expect(registers[13]).to have_property(:byte_size, 8)
+          expect(registers[14]).to have_property(:byte_size, 24)
         end
       end
 
@@ -188,6 +231,12 @@ RSpec.describe 'register/size' do
           expect(registers[6]).to have_property(:byte_size, [false], 8)
           expect(registers[7]).to have_property(:byte_size, [false], 8)
           expect(registers[8]).to have_property(:byte_size, [false], 8)
+          expect(registers[9]).to have_property(:byte_size, [false], 4)
+          expect(registers[10]).to have_property(:byte_size, [false], 4)
+          expect(registers[11]).to have_property(:byte_size, [false], 4)
+          expect(registers[12]).to have_property(:byte_size, [false], 4)
+          expect(registers[13]).to have_property(:byte_size, [false], 4)
+          expect(registers[14]).to have_property(:byte_size, [false], 4)
         end
       end
     end
@@ -226,6 +275,80 @@ RSpec.describe 'register/size' do
 
         expect(registers[8]).to have_property(:byte_size, 8)
         expect(registers[8]).to have_property(:byte_size, [false], 8)
+
+        expect(registers[9]).to have_property(:byte_size, 4)
+        expect(registers[9]).to have_property(:byte_size, [false], 4)
+
+        expect(registers[10]).to have_property(:byte_size, 4)
+        expect(registers[10]).to have_property(:byte_size, [false], 4)
+
+        expect(registers[11]).to have_property(:byte_size, 4)
+        expect(registers[11]).to have_property(:byte_size, [false], 4)
+
+        expect(registers[12]).to have_property(:byte_size, 4)
+        expect(registers[12]).to have_property(:byte_size, [false], 4)
+
+        expect(registers[13]).to have_property(:byte_size, 4)
+        expect(registers[13]).to have_property(:byte_size, [false], 4)
+
+        expect(registers[14]).to have_property(:byte_size, 4)
+        expect(registers[14]).to have_property(:byte_size, [false], 4)
+      end
+    end
+
+    context '引数hierarchicalにtrueが指定されてた場合' do
+      before do
+        registers.each do |register|
+          value = [true, false].sample
+          allow(register).to receive(:settings).and_return({ support_shared_address: value })
+        end
+      end
+
+      it '上位階層の配列サイズを入れたバイトサイズを返す' do
+        byte_size = registers[0].byte_size
+        expect(registers[0]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[1].byte_size
+        expect(registers[1]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[2].byte_size
+        expect(registers[2]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[3].byte_size
+        expect(registers[3]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[4].byte_size
+        expect(registers[4]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[5].byte_size
+        expect(registers[5]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[6].byte_size
+        expect(registers[6]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[7].byte_size
+        expect(registers[7]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[8].byte_size
+        expect(registers[8]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[9].byte_size
+        expect(registers[9]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[10].byte_size
+        expect(registers[10]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[11].byte_size
+        expect(registers[11]).to have_property(:byte_size, { hierarchical: true }, byte_size)
+
+        byte_size = registers[12].byte_size
+        expect(registers[12]).to have_property(:byte_size, { hierarchical: true }, 2 * 3 * byte_size)
+
+        byte_size = registers[13].byte_size
+        expect(registers[13]).to have_property(:byte_size, { hierarchical: true }, 2 * 3 * byte_size)
+
+        byte_size = registers[14].byte_size
+        expect(registers[14]).to have_property(:byte_size, { hierarchical: true }, 2 * 3 * byte_size)
       end
     end
   end
@@ -236,6 +359,19 @@ RSpec.describe 'register/size' do
         register { size [2] }
         register { size [2, 3] }
         register {}
+        register_file do
+          register { size [2] }
+          register { size [2, 3] }
+          register {}
+        end
+        register_file do
+          size [2, 3]
+          register_file do
+            register { size [2] }
+            register { size [2, 3] }
+            register {}
+          end
+        end
       end
     end
 
@@ -246,6 +382,18 @@ RSpec.describe 'register/size' do
 
         allow(registers[1]).to receive(:settings).and_return(support_array: true)
         expect(registers[1]).to have_property(:array?, true)
+
+        allow(registers[3]).to receive(:settings).and_return(support_array: true)
+        expect(registers[3]).to have_property(:array?, true)
+
+        allow(registers[4]).to receive(:settings).and_return(support_array: true)
+        expect(registers[4]).to have_property(:array?, true)
+
+        allow(registers[6]).to receive(:settings).and_return(support_array: true)
+        expect(registers[6]).to have_property(:array?, true)
+
+        allow(registers[7]).to receive(:settings).and_return(support_array: true)
+        expect(registers[7]).to have_property(:array?, true)
       end
     end
 
@@ -253,6 +401,12 @@ RSpec.describe 'register/size' do
       it '偽を返す' do
         allow(registers[2]).to receive(:settings).and_return(support_array: true)
         expect(registers[2]).to have_property(:array?, false)
+
+        allow(registers[5]).to receive(:settings).and_return(support_array: true)
+        expect(registers[5]).to have_property(:array?, false)
+
+        allow(registers[8]).to receive(:settings).and_return(support_array: true)
+        expect(registers[8]).to have_property(:array?, false)
       end
     end
 
@@ -266,6 +420,52 @@ RSpec.describe 'register/size' do
 
         allow(registers[2]).to receive(:settings).and_return({})
         expect(registers[2]).to have_property(:array?, false)
+
+        allow(registers[3]).to receive(:settings).and_return({})
+        expect(registers[3]).to have_property(:array?, false)
+
+        allow(registers[4]).to receive(:settings).and_return({})
+        expect(registers[4]).to have_property(:array?, false)
+
+        allow(registers[5]).to receive(:settings).and_return({})
+        expect(registers[5]).to have_property(:array?, false)
+
+        allow(registers[6]).to receive(:settings).and_return({})
+        expect(registers[6]).to have_property(:array?, false)
+
+        allow(registers[7]).to receive(:settings).and_return({})
+        expect(registers[7]).to have_property(:array?, false)
+
+        allow(registers[8]).to receive(:settings).and_return({})
+        expect(registers[8]).to have_property(:array?, false)
+      end
+    end
+
+    context '引数hierarchicalにtrueが指定されて' do
+      before do
+        registers.each do |register|
+          value = [true, false].sample
+          allow(register).to receive(:settings).and_return(support_array: value)
+        end
+      end
+
+      context '上位に配列レジスタファイル階層がない場合' do
+        it '引数未指定の場合と同じ結果を返す' do
+          expect(registers[0]).to have_property(:array?, { hierarchical: true }, registers[0].array?)
+          expect(registers[1]).to have_property(:array?, { hierarchical: true }, registers[1].array?)
+          expect(registers[2]).to have_property(:array?, { hierarchical: true }, registers[2].array?)
+          expect(registers[3]).to have_property(:array?, { hierarchical: true }, registers[3].array?)
+          expect(registers[4]).to have_property(:array?, { hierarchical: true }, registers[4].array?)
+          expect(registers[5]).to have_property(:array?, { hierarchical: true }, registers[5].array?)
+        end
+      end
+
+      context '上位に配列レジスタファイル階層を含む場合' do
+        it 'trueを返す' do
+          expect(registers[6]).to have_property(:array?, { hierarchical: true }, true)
+          expect(registers[7]).to have_property(:array?, { hierarchical: true }, true)
+          expect(registers[8]).to have_property(:array?, { hierarchical: true }, true)
+        end
       end
     end
   end
@@ -276,6 +476,19 @@ RSpec.describe 'register/size' do
         register { size [2] }
         register { size [2, 3] }
         register {}
+        register_file do
+          register { size [2] }
+          register { size [2, 3] }
+          register {}
+        end
+        register_file do
+          size [2, 3]
+          register_file do
+            register { size [2] }
+            register { size [2, 3] }
+            register {}
+          end
+        end
       end
     end
 
@@ -286,6 +499,18 @@ RSpec.describe 'register/size' do
 
         allow(registers[1]).to receive(:settings).and_return(support_array: true)
         expect(registers[1]).to have_property(:array_size, match([2, 3]))
+
+        allow(registers[3]).to receive(:settings).and_return(support_array: true)
+        expect(registers[3]).to have_property(:array_size, match([2]))
+
+        allow(registers[4]).to receive(:settings).and_return(support_array: true)
+        expect(registers[4]).to have_property(:array_size, match([2, 3]))
+
+        allow(registers[6]).to receive(:settings).and_return(support_array: true)
+        expect(registers[6]).to have_property(:array_size, match([2]))
+
+        allow(registers[7]).to receive(:settings).and_return(support_array: true)
+        expect(registers[7]).to have_property(:array_size, match([2, 3]))
       end
     end
 
@@ -299,6 +524,57 @@ RSpec.describe 'register/size' do
 
         allow(registers[2]).to receive(:settings).and_return(support_array: true)
         expect(registers[2]).to have_property(:array_size, nil)
+
+        allow(registers[3]).to receive(:settings).and_return({})
+        expect(registers[3]).to have_property(:array_size, nil)
+
+        allow(registers[4]).to receive(:settings).and_return({})
+        expect(registers[4]).to have_property(:array_size, nil)
+
+        allow(registers[5]).to receive(:settings).and_return(support_array: true)
+        expect(registers[5]).to have_property(:array_size, nil)
+
+        allow(registers[6]).to receive(:settings).and_return({})
+        expect(registers[6]).to have_property(:array_size, nil)
+
+        allow(registers[7]).to receive(:settings).and_return({})
+        expect(registers[7]).to have_property(:array_size, nil)
+
+        allow(registers[8]).to receive(:settings).and_return(support_array: true)
+        expect(registers[8]).to have_property(:array_size, nil)
+      end
+    end
+
+    context '引数hierarchicalにtrueが指定され' do
+      before do
+        registers.each do |register|
+          value = [true, false].sample
+          allow(register).to receive(:settings).and_return(support_array: value)
+        end
+      end
+
+      context '上位に配列レジスタファイル階層がない場合' do
+        it '引数未指定の場合と同じ結果を返す' do
+          expect(registers[0]).to have_property(:array_size, { hierarchical: true }, registers[0].array_size)
+          expect(registers[1]).to have_property(:array_size, { hierarchical: true }, registers[1].array_size)
+          expect(registers[2]).to have_property(:array_size, { hierarchical: true }, registers[2].array_size)
+          expect(registers[3]).to have_property(:array_size, { hierarchical: true }, registers[3].array_size)
+          expect(registers[4]).to have_property(:array_size, { hierarchical: true }, registers[4].array_size)
+          expect(registers[5]).to have_property(:array_size, { hierarchical: true }, registers[5].array_size)
+        end
+      end
+
+      context '上位に配列レジスタファイル階層を含む場合' do
+        it '上位のレジスタファイル階層の配列サイズを含んだ配列サイズを返す' do
+          size = registers[6].array_size
+          expect(registers[6]).to have_property(:array_size, { hierarchical: true }, [2, 3, *size])
+
+          size = registers[7].array_size
+          expect(registers[7]).to have_property(:array_size, { hierarchical: true }, [2, 3, *size])
+
+          size = registers[8].array_size
+          expect(registers[8]).to have_property(:array_size, { hierarchical: true }, [2, 3, *size])
+        end
       end
     end
   end


### PR DESCRIPTION
refs: https://github.com/rggen/rggen/issues/127#issuecomment-1362852719

This PR is to add `hierarchical` argument to following property methods of `size` feature.

* register/size#byte_size
* register/size#array?
* register/size#array_size

If this argument is true, these methods will also get a result from upper layers.
